### PR TITLE
Fix imports to work with DMD 2.086

### DIFF
--- a/source/quantities/internal/si.d
+++ b/source/quantities/internal/si.d
@@ -16,8 +16,9 @@ Generates SI units, prefixes and several utility functions
 +/
 mixin template SIDefinitions(N)
 {
+    import quantities.common : prefix;
     import quantities.compiletime : Quantity, isQuantity, unit, square, cubic;
-    import quantities.runtime : QVariant, isQVariantOrQuantity, prefix;
+    import quantities.runtime : QVariant, isQVariantOrQuantity;
     import quantities.parsing : SymbolList, Parser;
     import std.conv : parse;
     import std.math : PI;

--- a/source/quantities/runtime.d
+++ b/source/quantities/runtime.d
@@ -184,8 +184,6 @@ public:
     this(Q)(auto ref const Q qty)
             if (isQuantity!Q)
     {
-        import quantities.compiletime : qVariant;
-
         this = qty.qVariant;
     }
 


### PR DESCRIPTION
"Selective imports find symbols in private imports of other modules" [was deprecated in DMD 2.079](https://dlang.org/changelog/2.079.0.html#fix17630) and [became an error in DMD 2.086](https://dlang.org/changelog/2.086.0.html#error_visibility). The 2.086 changelog only mentions selective imports of private selective imports but the change also applies to selective imports of private non-selective imports ([see commit diff](https://github.com/dlang/dmd/pull/9393/files#diff-90e876a104f01c31442b3b307953221c)).