### PR TITLE
Removes nothrow from arithmetic operations (which lets it compile)

### DIFF
--- a/source/quantities/internal/dimensions.d
+++ b/source/quantities/internal/dimensions.d
@@ -262,37 +262,72 @@ private immutable(Dim)[] inverted(immutable(Dim)[] source) @safe pure nothrow
     return target.immut;
 }
 
-private void insertAndSort(ref Dim[] list, string symbol, Rational power, size_t rank) @safe pure nothrow
+version(LDC) // basic conditional compilation hack cause LDC's impl of insertInPlace is not nothrow
 {
-    auto pos = list.countUntil!(d => d.symbol == symbol)();
-    if (pos >= 0)
+    private void insertAndSort(ref Dim[] list, string symbol, Rational power, size_t rank) @safe pure
     {
-        // Merge the dimensions
-        list[pos].power += power;
-        if (list[pos].power == 0)
+        auto pos = list.countUntil!(d => d.symbol == symbol)();
+        if (pos >= 0)
         {
-            try
-                list = list.remove(pos);
-            catch (Exception) // remove only throws when it has multiple arguments
-                assert(false);
+            // Merge the dimensions
+            list[pos].power += power;
+            if (list[pos].power == 0)
+            {
+                try
+                    list = list.remove(pos);
+                catch (Exception) // remove only throws when it has multiple arguments
+                    assert(false);
 
-            // Necessary to compare dimensionless values
-            if (!list.length)
-                list = null;
+                // Necessary to compare dimensionless values
+                if (!list.length)
+                    list = null;
+            }
         }
+        else
+        {
+            // Insert the new dimension
+            auto dim = Dim(symbol, power, rank);
+            pos = list.countUntil!(d => d > dim);
+            if (pos < 0)
+                pos = list.length;
+            list.insertInPlace(pos, dim);
+        }
+        assert(list.isSorted);
     }
-    else
-    {
-        // Insert the new dimension
-        auto dim = Dim(symbol, power, rank);
-        pos = list.countUntil!(d => d > dim);
-        if (pos < 0)
-            pos = list.length;
-        list.insertInPlace(pos, dim);
-    }
-    assert(list.isSorted);
 }
+else
+{
+    private void insertAndSort(ref Dim[] list, string symbol, Rational power, size_t rank) @safe pure nothrow
+    {
+        auto pos = list.countUntil!(d => d.symbol == symbol)();
+        if (pos >= 0)
+        {
+            // Merge the dimensions
+            list[pos].power += power;
+            if (list[pos].power == 0)
+            {
+                try
+                    list = list.remove(pos);
+                catch (Exception) // remove only throws when it has multiple arguments
+                    assert(false);
 
+                // Necessary to compare dimensionless values
+                if (!list.length)
+                    list = null;
+            }
+        }
+        else
+        {
+            // Insert the new dimension
+            auto dim = Dim(symbol, power, rank);
+            pos = list.countUntil!(d => d > dim);
+            if (pos < 0)
+                pos = list.length;
+            list.insertInPlace(pos, dim);
+        }
+        assert(list.isSorted);
+    }
+}
 private immutable(Dim)[] immut(Dim[] source) @trusted pure nothrow
 {
     if (__ctfe)
@@ -301,28 +336,52 @@ private immutable(Dim)[] immut(Dim[] source) @trusted pure nothrow
         return source.assumeUnique;
 }
 
-private immutable(Dim)[] insertSorted(immutable(Dim)[] source, string symbol,
-        Rational power, size_t rank) @safe pure nothrow
+version(LDC)
 {
-    if (power == 0)
-        return source;
+    private immutable(Dim)[] insertSorted(immutable(Dim)[] source, string symbol,
+            Rational power, size_t rank) @safe pure
+    {
+        if (power == 0)
+            return source;
 
-    if (!source.length)
-        return [Dim(symbol, power, rank)].immut;
+        if (!source.length)
+            return [Dim(symbol, power, rank)].immut;
 
-    Dim[] list = source.dup;
-    insertAndSort(list, symbol, power, rank);
-    return list.immut;
+        Dim[] list = source.dup;
+        insertAndSort(list, symbol, power, rank);
+        return list.immut;
+    }
+    private immutable(Dim)[] insertSorted(immutable(Dim)[] source, immutable(Dim)[] other) @safe pure
+    {
+        Dim[] list = source.dup;
+        foreach (dim; other)
+            insertAndSort(list, dim.symbol, dim.power, dim.rank);
+        return list.immut;
+    }
 }
-
-private immutable(Dim)[] insertSorted(immutable(Dim)[] source, immutable(Dim)[] other) @safe pure nothrow
+else
 {
-    Dim[] list = source.dup;
-    foreach (dim; other)
-        insertAndSort(list, dim.symbol, dim.power, dim.rank);
-    return list.immut;
-}
+    private immutable(Dim)[] insertSorted(immutable(Dim)[] source, string symbol,
+            Rational power, size_t rank) @safe pure nothrow
+    {
+        if (power == 0)
+            return source;
 
+        if (!source.length)
+            return [Dim(symbol, power, rank)].immut;
+
+        Dim[] list = source.dup;
+        insertAndSort(list, symbol, power, rank);
+        return list.immut;
+    }
+    private immutable(Dim)[] insertSorted(immutable(Dim)[] source, immutable(Dim)[] other) @safe pure nothrow
+    {
+        Dim[] list = source.dup;
+        foreach (dim; other)
+            insertAndSort(list, dim.symbol, dim.power, dim.rank);
+        return list.immut;
+    }
+}
 /// A vector of dimensions
 struct Dimensions
 {
@@ -372,7 +431,22 @@ public:
     {
         return Dimensions(_dims.inverted);
     }
+version(LDC)
+{
+    Dimensions opBinary(string op)(const Dimensions other) @safe pure const 
+            if (op == "*")
+    {
+        return Dimensions(_dims.insertSorted(other._dims));
+    }
 
+    Dimensions opBinary(string op)(const Dimensions other) @safe pure const 
+            if (op == "/")
+    {
+        return Dimensions(_dims.insertSorted(other._dims.inverted));
+    }
+}
+else
+{
     Dimensions opBinary(string op)(const Dimensions other) @safe pure nothrow const 
             if (op == "*")
     {
@@ -384,7 +458,7 @@ public:
     {
         return Dimensions(_dims.insertSorted(other._dims.inverted));
     }
-
+}
     Dimensions pow(Rational n) @safe pure nothrow const
     {
         if (n == 0)
@@ -461,7 +535,42 @@ unittest
     auto inv = [Dim("A", -2), Dim("B", 2)].idup;
     assert(list.inverted == inv);
 }
+version(LDC) // if you have a problem with this, take it up with LDC for having a non-nothrow impl of insertSorted
+{
+@("Dim[].insertAndSort")
+@safe pure unittest
+{
+    Dim[] list;
+    list.insertAndSort("A", Rational(1), 1);
+    assert(list == [Dim("A", 1, 1)]);
+    list.insertAndSort("A", Rational(1), 1);
+    assert(list == [Dim("A", 2, 1)]);
+    list.insertAndSort("A", Rational(-2), 1);
+    assert(list.length == 0);
+    list.insertAndSort("B", Rational(1), 3);
+    assert(list == [Dim("B", 1, 3)]);
+    list.insertAndSort("C", Rational(1), 1);
+    assert(Dim("C", 1, 1) < Dim("B", 1, 3));
+    assert(list == [Dim("C", 1, 1), Dim("B", 1, 3)]);
+}
 
+@("Dimensions *")
+@safe pure unittest
+{
+    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+    auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
+    assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
+}
+@("Dimensions /")
+@safe pure unittest
+{
+    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+    auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
+    assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
+}
+}
+else
+{
 @("Dim[].insertAndSort")
 @safe pure nothrow unittest
 {
@@ -486,7 +595,6 @@ unittest
     auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
     assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
 }
-
 @("Dimensions /")
 @safe pure nothrow unittest
 {
@@ -494,7 +602,7 @@ unittest
     auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
     assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
 }
-
+}
 @("Dimensions pow")
 @safe pure nothrow unittest
 {

--- a/source/quantities/internal/dimensions.d
+++ b/source/quantities/internal/dimensions.d
@@ -535,73 +535,73 @@ unittest
     auto inv = [Dim("A", -2), Dim("B", 2)].idup;
     assert(list.inverted == inv);
 }
-version(LDC) // if you have a problem with this, take it up with LDC for having a non-nothrow impl of insertSorted
+version(LDC) // TEMPORARY, I HOPE HOPE HOPE
 {
-@("Dim[].insertAndSort")
-@safe pure unittest
-{
-    Dim[] list;
-    list.insertAndSort("A", Rational(1), 1);
-    assert(list == [Dim("A", 1, 1)]);
-    list.insertAndSort("A", Rational(1), 1);
-    assert(list == [Dim("A", 2, 1)]);
-    list.insertAndSort("A", Rational(-2), 1);
-    assert(list.length == 0);
-    list.insertAndSort("B", Rational(1), 3);
-    assert(list == [Dim("B", 1, 3)]);
-    list.insertAndSort("C", Rational(1), 1);
-    assert(Dim("C", 1, 1) < Dim("B", 1, 3));
-    assert(list == [Dim("C", 1, 1), Dim("B", 1, 3)]);
-}
+    @("Dim[].insertAndSort")
+    @safe pure unittest
+    {
+        Dim[] list;
+        list.insertAndSort("A", Rational(1), 1);
+        assert(list == [Dim("A", 1, 1)]);
+        list.insertAndSort("A", Rational(1), 1);
+        assert(list == [Dim("A", 2, 1)]);
+        list.insertAndSort("A", Rational(-2), 1);
+        assert(list.length == 0);
+        list.insertAndSort("B", Rational(1), 3);
+        assert(list == [Dim("B", 1, 3)]);
+        list.insertAndSort("C", Rational(1), 1);
+        assert(Dim("C", 1, 1) < Dim("B", 1, 3));
+        assert(list == [Dim("C", 1, 1), Dim("B", 1, 3)]);
+    }
 
-@("Dimensions *")
-@safe pure unittest
-{
-    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
-    auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
-    assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
-}
-@("Dimensions /")
-@safe pure unittest
-{
-    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
-    auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
-    assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
-}
+    @("Dimensions *")
+    @safe pure unittest
+    {
+        auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+        auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
+        assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
+    }
+    @("Dimensions /")
+    @safe pure unittest
+    {
+        auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+        auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
+        assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
+    }
 }
 else
 {
-@("Dim[].insertAndSort")
-@safe pure nothrow unittest
-{
-    Dim[] list;
-    list.insertAndSort("A", Rational(1), 1);
-    assert(list == [Dim("A", 1, 1)]);
-    list.insertAndSort("A", Rational(1), 1);
-    assert(list == [Dim("A", 2, 1)]);
-    list.insertAndSort("A", Rational(-2), 1);
-    assert(list.length == 0);
-    list.insertAndSort("B", Rational(1), 3);
-    assert(list == [Dim("B", 1, 3)]);
-    list.insertAndSort("C", Rational(1), 1);
-    assert(Dim("C", 1, 1) < Dim("B", 1, 3));
-    assert(list == [Dim("C", 1, 1), Dim("B", 1, 3)]);
-}
+    @("Dim[].insertAndSort")
+    @safe pure nothrow unittest
+    {
+        Dim[] list;
+        list.insertAndSort("A", Rational(1), 1);
+        assert(list == [Dim("A", 1, 1)]);
+        list.insertAndSort("A", Rational(1), 1);
+        assert(list == [Dim("A", 2, 1)]);
+        list.insertAndSort("A", Rational(-2), 1);
+        assert(list.length == 0);
+        list.insertAndSort("B", Rational(1), 3);
+        assert(list == [Dim("B", 1, 3)]);
+        list.insertAndSort("C", Rational(1), 1);
+        assert(Dim("C", 1, 1) < Dim("B", 1, 3));
+        assert(list == [Dim("C", 1, 1), Dim("B", 1, 3)]);
+    }
 
-@("Dimensions *")
-@safe pure nothrow unittest
-{
-    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
-    auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
-    assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
-}
-@("Dimensions /")
-@safe pure nothrow unittest
-{
-    auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
-    auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
-    assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
-}
+    @("Dimensions *")
+    @safe pure nothrow unittest
+    {
+        auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+        auto dim2 = Dimensions([Dim("a", -1), Dim("c", 2)]);
+        assert(dim1 * dim2 == Dimensions([Dim("b", -2), Dim("c", 2)]));
+    }
+    @("Dimensions /")
+    @safe pure nothrow unittest
+    {
+        auto dim1 = Dimensions([Dim("a", 1), Dim("b", -2)]);
+        auto dim2 = Dimensions([Dim("a", 1), Dim("c", 2)]);
+        assert(dim1 / dim2 == Dimensions([Dim("b", -2), Dim("c", -2)]));
+    }
 }
 @("Dimensions pow")
 @safe pure nothrow unittest

--- a/tests/quantity_tests.d
+++ b/tests/quantity_tests.d
@@ -145,7 +145,28 @@ alias Angle = typeof(radian);
     auto m6 = 10 % (2 * radian);
     assert(m6.value(radian).approxEqual(0));
 }
+version(LDC)
+{
+@("opBinary Q*Q, Q/Q, Q%Q")
+@safe pure unittest
+{
+    auto surface = (10 * meter) * (10 * meter);
+    assert(surface.value(meter * meter).approxEqual(100));
+    assert(surface.dimensions == meter.dimensions.pow(2));
 
+    auto speed = (10 * meter) / (5 * second);
+    assert(speed.value(meter / second).approxEqual(2));
+    assert(speed.dimensions == meter.dimensions / second.dimensions);
+
+    auto surfaceMod10 = surface % (10 * meter * meter);
+    assert(surfaceMod10.value(meter * meter).approxEqual(0));
+    assert(surfaceMod10.dimensions == surface.dimensions);
+
+    assert(!__traits(compiles, meter % second));
+}
+}
+else
+{
 @("opBinary Q*Q, Q/Q, Q%Q")
 @safe pure nothrow unittest
 {
@@ -163,7 +184,7 @@ alias Angle = typeof(radian);
 
     assert(!__traits(compiles, meter % second));
 }
-
+}
 @("opBinary Q^^I Q^^R")
 @safe pure nothrow unittest
 {

--- a/tests/quantity_tests.d
+++ b/tests/quantity_tests.d
@@ -147,43 +147,43 @@ alias Angle = typeof(radian);
 }
 version(LDC)
 {
-@("opBinary Q*Q, Q/Q, Q%Q")
-@safe pure unittest
-{
-    auto surface = (10 * meter) * (10 * meter);
-    assert(surface.value(meter * meter).approxEqual(100));
-    assert(surface.dimensions == meter.dimensions.pow(2));
+    @("opBinary Q*Q, Q/Q, Q%Q")
+    @safe pure unittest
+    {
+        auto surface = (10 * meter) * (10 * meter);
+        assert(surface.value(meter * meter).approxEqual(100));
+        assert(surface.dimensions == meter.dimensions.pow(2));
 
-    auto speed = (10 * meter) / (5 * second);
-    assert(speed.value(meter / second).approxEqual(2));
-    assert(speed.dimensions == meter.dimensions / second.dimensions);
+        auto speed = (10 * meter) / (5 * second);
+        assert(speed.value(meter / second).approxEqual(2));
+        assert(speed.dimensions == meter.dimensions / second.dimensions);
 
-    auto surfaceMod10 = surface % (10 * meter * meter);
-    assert(surfaceMod10.value(meter * meter).approxEqual(0));
-    assert(surfaceMod10.dimensions == surface.dimensions);
+        auto surfaceMod10 = surface % (10 * meter * meter);
+        assert(surfaceMod10.value(meter * meter).approxEqual(0));
+        assert(surfaceMod10.dimensions == surface.dimensions);
 
-    assert(!__traits(compiles, meter % second));
-}
+        assert(!__traits(compiles, meter % second));
+    }
 }
 else
 {
-@("opBinary Q*Q, Q/Q, Q%Q")
-@safe pure nothrow unittest
-{
-    auto surface = (10 * meter) * (10 * meter);
-    assert(surface.value(meter * meter).approxEqual(100));
-    assert(surface.dimensions == meter.dimensions.pow(2));
+    @("opBinary Q*Q, Q/Q, Q%Q")
+    @safe pure nothrow unittest
+    {
+        auto surface = (10 * meter) * (10 * meter);
+        assert(surface.value(meter * meter).approxEqual(100));
+        assert(surface.dimensions == meter.dimensions.pow(2));
 
-    auto speed = (10 * meter) / (5 * second);
-    assert(speed.value(meter / second).approxEqual(2));
-    assert(speed.dimensions == meter.dimensions / second.dimensions);
+        auto speed = (10 * meter) / (5 * second);
+        assert(speed.value(meter / second).approxEqual(2));
+        assert(speed.dimensions == meter.dimensions / second.dimensions);
 
-    auto surfaceMod10 = surface % (10 * meter * meter);
-    assert(surfaceMod10.value(meter * meter).approxEqual(0));
-    assert(surfaceMod10.dimensions == surface.dimensions);
+        auto surfaceMod10 = surface % (10 * meter * meter);
+        assert(surfaceMod10.value(meter * meter).approxEqual(0));
+        assert(surfaceMod10.dimensions == surface.dimensions);
 
-    assert(!__traits(compiles, meter % second));
-}
+        assert(!__traits(compiles, meter % second));
+    }
 }
 @("opBinary Q^^I Q^^R")
 @safe pure nothrow unittest

--- a/tests/quantity_tests.d
+++ b/tests/quantity_tests.d
@@ -145,45 +145,22 @@ alias Angle = typeof(radian);
     auto m6 = 10 % (2 * radian);
     assert(m6.value(radian).approxEqual(0));
 }
-version(LDC)
+@("opBinary Q*Q, Q/Q, Q%Q")
+@safe pure unittest
 {
-    @("opBinary Q*Q, Q/Q, Q%Q")
-    @safe pure unittest
-    {
-        auto surface = (10 * meter) * (10 * meter);
-        assert(surface.value(meter * meter).approxEqual(100));
-        assert(surface.dimensions == meter.dimensions.pow(2));
+    auto surface = (10 * meter) * (10 * meter);
+    assert(surface.value(meter * meter).approxEqual(100));
+    assert(surface.dimensions == meter.dimensions.pow(2));
 
-        auto speed = (10 * meter) / (5 * second);
-        assert(speed.value(meter / second).approxEqual(2));
-        assert(speed.dimensions == meter.dimensions / second.dimensions);
+    auto speed = (10 * meter) / (5 * second);
+    assert(speed.value(meter / second).approxEqual(2));
+    assert(speed.dimensions == meter.dimensions / second.dimensions);
 
-        auto surfaceMod10 = surface % (10 * meter * meter);
-        assert(surfaceMod10.value(meter * meter).approxEqual(0));
-        assert(surfaceMod10.dimensions == surface.dimensions);
+    auto surfaceMod10 = surface % (10 * meter * meter);
+    assert(surfaceMod10.value(meter * meter).approxEqual(0));
+    assert(surfaceMod10.dimensions == surface.dimensions);
 
-        assert(!__traits(compiles, meter % second));
-    }
-}
-else
-{
-    @("opBinary Q*Q, Q/Q, Q%Q")
-    @safe pure nothrow unittest
-    {
-        auto surface = (10 * meter) * (10 * meter);
-        assert(surface.value(meter * meter).approxEqual(100));
-        assert(surface.dimensions == meter.dimensions.pow(2));
-
-        auto speed = (10 * meter) / (5 * second);
-        assert(speed.value(meter / second).approxEqual(2));
-        assert(speed.dimensions == meter.dimensions / second.dimensions);
-
-        auto surfaceMod10 = surface % (10 * meter * meter);
-        assert(surfaceMod10.value(meter * meter).approxEqual(0));
-        assert(surfaceMod10.dimensions == surface.dimensions);
-
-        assert(!__traits(compiles, meter % second));
-    }
+    assert(!__traits(compiles, meter % second));
 }
 @("opBinary Q^^I Q^^R")
 @safe pure nothrow unittest


### PR DESCRIPTION
Actually I was totally wrong, DMD has this issue too, my DMD was just outdated. I've just removed nothrow for now, any semblance of compatibility be damned. I'm using this for a project where complicated dependencies compiler-wise would be absolute hell and I would rather deal with the loss of nothrow than that. I don't know when the breaking change occurred in particular and I'm not quite sure how it might be fixed. I would rather genuinely fix it than just remove nothrow, but that'd require making a separate, nothrow implementation of insertInPlace, which is not ideal.

Original comment:
.
.
.
The most recent version of LDC2 (1.12 is working, later don't seem to be) weren't allowing this to compile. This allows it to compile on more recent versions, at the expense of removing `nothrow` from arithmetic operations on quantities when compiled using LDC (and *only* when using LDC).

This is of course due to the fact that LDC's--and *only* LDC's--implementation of insertInPlace has recently lost `nothrow`, which means insertAndSort, insertSorted etc. cascading on down can no longer be marked `nothrow`. This is... very annoying, but I personally would prefer not having nothrow over not being able to use LDC. I would recommend periodically checking to see if this terrible patch can be patched back out, or more likely I'll do it myself, though I wouldn't rely on that. Code is a liability etc., this is explicitly a *bad patch* but it's better than the previous situation, which was being unable to compile at all.

Regardless: it'd probably be better to bring this inconsistency up to LDC. For the record, it seems to work perfectly fine compiling with DMD, and on DMD you'll still get nothrow.